### PR TITLE
Fixed an error in the production example mapping

### DIFF
--- a/docs/source/examples/options/mappings/production.yaml
+++ b/docs/source/examples/options/mappings/production.yaml
@@ -1,5 +1,5 @@
 # A production stack, so big instances, lots of scaling!
-StackRole: testing
+StackRole: production
 AppServerAvailabilityZones:
     - us-east-1a
     - us-east-1d

--- a/docs/source/examples/options/production.json
+++ b/docs/source/examples/options/production.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "My static webapp testing stack",
+  "Description": "My static webapp production stack",
   "Resources": {
     "LoadBalancer": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
@@ -76,7 +76,7 @@
         "Tags": [
           {
             "PropagateAtLaunch": true,
-            "Value": "testing-static-app-server",
+            "Value": "production-static-app-server",
             "Key": "Name"
           }
         ],


### PR DESCRIPTION
The "production" stackrole was still "testing" due to copypasta. Fixed!
