### PR TITLE
Factor out the generator to make it callable from other python scripts

### DIFF
--- a/cfn_pyplates/cli.py
+++ b/cfn_pyplates/cli.py
@@ -93,16 +93,14 @@ def callable_generate(pyplate, outfile=None, options=None):
     except Error as e:
         print 'Error processing the pyplate:'
         print e.message
-        return 1
+        return
 
     if outfile:
         if not isinstance(outfile, file):
             outfile = _openwritable(outfile)
         outfile.write(output)
-    else:
-        print output
 
-    return 0
+    return output
 
 
 def generate():
@@ -150,4 +148,11 @@ WARNING!
     })
     args = scheme.validate(args)
 
-    return callable_generate(args['<pyplate>'], args['<outfile>'], args['--options'])
+    out = callable_generate(args['<pyplate>'], args['<outfile>'], args['--options'])
+
+    if not out:
+        return 1
+    elif not args['<outfile>']:
+        print out
+
+    return 0

--- a/cfn_pyplates/cli.py
+++ b/cfn_pyplates/cli.py
@@ -78,6 +78,8 @@ def callable_generate(pyplate, outfile=None, options=None):
         if not isinstance(options, file):
             options = open(options)
         options = yaml.load(options)
+    else:
+        options = {}
 
     options_mapping = OptionsMapping(options)
 


### PR DESCRIPTION
In the process af attempting to write some scripts for automatically provisioning amazon instances, a colleague of mine resorted to using subprocess to call the cli.

This factors out the generation such that it can be usefully called from other modules.