### PR TITLE
Single typo in the docs that fail CloudFormation Example

### DIFF
--- a/docs/source/examples/simple/out.json
+++ b/docs/source/examples/simple/out.json
@@ -6,7 +6,7 @@
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "InstanceType": "m1.small",
-        "ImageID": "ami-c30360aa"
+        "ImageId": "ami-c30360aa"
       }
     }
   }


### PR DESCRIPTION
Thank you for maintaining this project. It has helped my out already. I noticed the first simple example has one typo that causes CloudFormation to fail. Since this is the first example, it confused me the first time I saw it while learning about CloudFormation.

Reading the AWS docs at http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html
The variable name is ImageId not ImageID. This is minor but will help the next person down the line,