### PR TITLE
* Add user_file function to functions.py

### DIFF
--- a/cfn_pyplates/functions.py
+++ b/cfn_pyplates/functions.py
@@ -67,6 +67,7 @@ __all__ = [
     'c_not',
     'c_if',
     'c_equals',
+    'user_file'
 ]
 
 
@@ -358,3 +359,53 @@ def c_if(condition_name, value_if_true, value_if_false):
 
     """
     return {'Fn::If': [condition_name, value_if_true, value_if_false]}
+
+def user_file(thefile, args = None):
+    """This method attempts to allow easy inclusion of a file with optional reference value insertions
+
+    Returns one value containing the data to pass to a "content" element of a
+    "file" entry.  This method takes care of reading in the file, iterating
+    through the lines, substituting reference values if present, and then
+    returning either just a string (single-line file) or a dictionary using
+    the "join" method.
+
+    Reference values are substituted by placing 4 underscores (____) in the
+    passed file where a reference value should be substituted.  Those
+    placeholders are then replaced in order of appearance in the file with
+    references in the "args" parameter.
+
+    Reference value substitution taken from another CloudFormations library at:
+    https://github.com/devstructure/python-cloudformation/blob/master/cloudformation/__init__.py#L66-L89
+
+    """
+    lines = []
+    data = []
+
+    if args:
+        iterargs = iter(args)
+
+    fd = open(thefile, "r")
+    for line in fd:
+        data.append(line.rstrip().split("____"))
+    fd.close()
+
+    for parts in data:
+        if 1 == len(parts):
+            lines.append(parts[0])
+        else:
+            line = []
+
+            for part in parts:
+                line.extend([part, None])
+            line.pop()
+
+            for i in range(len(line)):
+                if line[i] is None:
+                    line[i] = iterargs.next()
+
+            lines.append(join("", *line))
+
+    if len(lines) > 1:
+        return join("\n", *lines)
+    else:
+        return lines[0]


### PR DESCRIPTION
I added a function to functions.py that I'm hoping will be valuable to others using this library.  Most of the code for it was lifted from:

https://github.com/devstructure/python-cloudformation/blob/master/cloudformation/__init__.py#L66-L89

which I have used previously.  Basically, this allows you to read in a file which you would like to include in a CloudFormation config and have it automatically placed in the CF template using the correct "Fn::Join" process.  For example, let's say you have a simple user_data script like:

```bash
#!/bin/bash
INSTANCEID=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`

function error_exit {
  cfn-signal -e 1 '____'
  exit 1
}

/opt/aws/bin/cfn-init --region ____ -s ____ -r SeqProd || error_exit 'Failed to bootstrap'
```

You can then do something like the following in a template.py file:

```python
user_data_script = user_file(
    "userdata.sh",
    [
        ref("TheInstanceWaitHandle"),
        ref("AWS::Region"),
        ref("AWS::StackName")
    ]
)
```
You can then just add this to an EC2 instance's properties using:

```python
"UserData": base64(user_data_script)
```

What you get in the output is:
```JSON
"UserData": {
  "Fn::Base64": {
    "Fn::Join": [
      "\n",
      [
        "#!/bin/bash",
        "INSTANCEID=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`",
        "",
        "function error_exit {",
        {
          "Fn::Join": [
            "",
            [
              "  cfn-signal -e 1 '",
              {
                "Ref": "TheInstanceWaitHandle"
              },
              "'"
            ]
          ]
        },
        "  exit 1",
        "}",
        "",
        {
          "Fn::Join": [
            "",
            [
              "/opt/aws/bin/cfn-init --region ",
              {
                "Ref": "AWS::Region"
              },
              " -s ",
              {
                "Ref": "AWS::StackName"
              },
              " -r SeqProd || error_exit 'Failed to bootstrap'"
            ]
          ]
        }
      ]
    ]
  }
},
```
This will then take care of reading in the file, replacing the "____" with the referenced `Ref` values, and adding it to the template correctly.  You can even pass normal files that do not require reference value substitution as an easy way to just include files.