### PR TITLE
Replace `distribute` with `setuptools`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-distribute
+setuptools
 docopt
 ordereddict
 pbr


### PR DESCRIPTION
`distribute` has been deprecated for ~2.5 years.
